### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ OBJECTS=$(patsubst %.c,%.o,$(SOURCES))
 TEST_SRC=$(wildcard tests/*_tests.c)
 TESTS=$(patsubst %.c,%,$(TEST_SRC))
 
-TARGET=2048-cli
+TARGET=./build/2048-cli
+
+.PHONY: all tests clean check
 
 # The target build
 all: $(TARGET) tests
@@ -22,9 +24,10 @@ build:
 	@mkdir -p bin
 
 # The Unit Tests
-.PHONY: tests
-tests: $(TESTS) $(OBJECTS)
-	$(CC) $(CFLAGS) -o $(patsubst %.c,%,$(@)) $@ $(OBJECTS)
+$(TESTS): $(OBJECTS)
+	$(CC) $(CFLAGS) -o $@ $(patsubst %,%.c,$(@)) $(OBJECTS)
+
+tests: $(TESTS)
 	sh ./tests/runtests.sh
 
 # The cleaner


### PR DESCRIPTION
Added an explicit compilation step for the test executable. You need to separate them if you want to keep the `tests` target a phony one.
Also my suggestion on the forum was a little off, switched around the substitutions. That `patsubst` solution is awkward anyway, but I haven't found a better way to have make compile a bunch of target files from single source files.